### PR TITLE
Explore posts by tags

### DIFF
--- a/src/components/ArticleListCard.tsx
+++ b/src/components/ArticleListCard.tsx
@@ -6,7 +6,8 @@ import unixToDateTime from '../utils/datetime'
 import { Link } from 'react-router-dom';
 
 type Props = {
-    article: any
+    article: any,
+    onTagClick: (tag: string) => void
 }
 
 function ArticleListCard(props: Props) {
@@ -26,7 +27,7 @@ function ArticleListCard(props: Props) {
     return (
         <div className="article-list-card card">
             <h2>
-                <Link to={`view/${props.article.id}`}>
+                <Link to={`/view/${props.article.id}`}>
                     {title}
                 </Link>
             </h2>
@@ -40,12 +41,12 @@ function ArticleListCard(props: Props) {
                 {unixToDateTime(props.article.unixTime)}
             </div>
             {scribe_tags.map((tag: any, index: number) => {
-                return <Chip
+                return  <Chip
                     key={tag.value}
-                    // onClick={() => console.log('clicked')}
                     label={tag.value.toUpperCase()}
                     className="chip"
                     variant="outlined"
+                    onClick={() => { props.onTagClick(tag.value.toLowerCase()) }}
                 />
             })}
 

--- a/src/components/ViewArticle.tsx
+++ b/src/components/ViewArticle.tsx
@@ -4,21 +4,29 @@ import ReactHtmlParser from 'react-html-parser';
 import LoadingComponent from './common/LoadingComponent'
 import './viewArticle.css'
 import ErrorComponent from './common/ErrorComonent';
+import Chip from '@material-ui/core/Chip';
+import { IArticleContent } from '../types/types';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
-const ViewArticle = (props: any) => {
+const ViewArticle = (props: RouteComponentProps<{id: string}>) => {
 	const { match } = props
 	const api = new ApiService
+	
 
-	const [articleData, setArticleData] = useState()
+	const [articleData, setArticleData] = useState<IArticleContent|null>()
 	const [error, setError] = useState()
 
 	useEffect(() => {
-		api.getArticleData(match.params.id).then((data: any) => {
-			setArticleData(data);
+		api.getArticleData(match.params.id).then((article: IArticleContent) => {
+			setArticleData(article);
 		}).catch(err => {
 			setError(err)
 		})
 	}, []);
+
+	const exploreTag = (tag: string) => {
+		props.history.push(`/explore/${tag}`);
+	};
 
 	return (
 		<div className="page article-view">
@@ -30,6 +38,17 @@ const ViewArticle = (props: any) => {
 						</h1>
 						<div className='view-article-tagline'></div>
 						<div>{ReactHtmlParser(articleData.body)}</div>
+						<div>
+						{articleData.tags.map((tag: any) => {
+							return  <Chip
+								key={tag.value}
+								label={tag.toUpperCase()}
+								className="chip"
+								variant="outlined"
+								onClick={() => { exploreTag(tag.toLowerCase()) }}
+							/>
+						})}
+						</div>
 					</div>
 					:
 					error
@@ -43,4 +62,4 @@ const ViewArticle = (props: any) => {
 
 }
 
-export default ViewArticle
+export default withRouter(ViewArticle)

--- a/src/components/navigation/navLinks.ts
+++ b/src/components/navigation/navLinks.ts
@@ -19,6 +19,13 @@ const navLinks: INavLink[] = [
 		nav: true
 	},
 	{
+		link: '/explore/:tag',
+		title: 'Explore tag',
+		component: ArticleIndex,
+		id: 4,
+		nav: true
+	},
+	{
 		link: '/view/:id',
 		title: 'View',
 		component: ViewArticle,

--- a/src/services/ApiService.tsx
+++ b/src/services/ApiService.tsx
@@ -1,6 +1,7 @@
 import Arweave from 'arweave/web'
 import { IArticle } from '../types/types';
 import sanitize from '../utils/sanitizeHtml';
+import { query as arqlQuery} from '../utils/arql';
 
 const arweave = Arweave.init(
 	{ host: 'arweave.net', port: 443, protocol: 'https' });
@@ -44,6 +45,36 @@ export default class ApiService {
 		}
 		try {
 			const res = await awv.api.post(`arql`, query)
+			return this.createRows(res)
+		}
+		catch (err) {
+			return { err }
+		}
+	}
+
+	public async getArticlesByTag(tag: string, awv: any = arweave) {
+
+		let query =
+		{
+			op: 'and',
+			expr1: {
+				op: 'equals',
+				expr1: 'App-Name',
+				expr2: prefix
+			},
+			expr2: arqlQuery({
+				[prefix + '-tag']: tag,
+				[prefix + '-tag-0']: tag,
+				[prefix + '-tag-1']: tag,
+				[prefix + '-tag-2']: tag,
+				[prefix + '-tag-3']: tag,
+				[prefix + '-tag-4']: tag,
+				[prefix + '-tag-5']: tag,
+			},'or')
+		}
+
+		try {
+			const res = await awv.api.post(`arql`, query); 
 			return this.createRows(res)
 		}
 		catch (err) {
@@ -138,7 +169,7 @@ export default class ApiService {
 
 	private addContentTags(tx: any, tags: string[]) {
 		tags.forEach((tag: string, index: number) => {
-			tx.addTag(`${prefix}-tag-${index}`, tag)
+			tx.addTag(`${prefix}-tag`, tag)
 		})
 		return tx
 	}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -26,6 +26,7 @@ export interface IArticleContent {
 	body: string
 	stringBody?: string
 	featuredImg?: IArticleImg
+	tags?:string[]
 }
 
 export type ArticleTag = string

--- a/src/utils/arql.tsx
+++ b/src/utils/arql.tsx
@@ -1,0 +1,33 @@
+
+type Operator = 'and' | 'or' | 'equals'
+interface Tags {
+    [key:string]: string
+}
+
+interface Query {
+    op: string
+    expr1: string | Query
+    expr2: string | Query
+}
+
+export function query(tags: Tags, operator: Operator){
+    return Object.entries(tags).reduce((previous: Query|null, current: [string, string]): Query => {
+        if (!previous) {
+            return {
+                op: 'equals',
+                expr1: current[0],
+                expr2: current[1]
+            };
+        }
+        return {
+            op: operator,
+            expr1: {
+                op: 'equals',
+                expr1: current[0],
+                expr2: current[1]
+            },
+            expr2: previous
+        }
+    },null);
+}
+


### PR DESCRIPTION
I've made tags on the index page clickable, clicking a tag will send the user to route`/explore/:tag` and will filter posts to that tag only.

The `/view/:id` view also has tags listed, and clicking them will also send the user to `/explore/:tag`.

I added an ARQL query helper method as the query is a bit complex and needs to query tags with numeric suffixes.

```
[prefix + '-tag']: tag,
[prefix + '-tag-0']: tag,
[prefix + '-tag-1']: tag,
[prefix + '-tag-2']: tag,
[prefix + '-tag-3']: tag,
[prefix + '-tag-4']: tag,
[prefix + '-tag-5']: tag,
```

I think in future tags could be added without the numeric suffix, as it's possible on Arweave to add the same tag multiple times with different values to the same transaction. The tags structure is an array of objects, each object has a key and values, rather than the whole tag structure itself being a key/value object.

```json
[{"key": "some-tag", "value": "some-value"}]
```
vs
```json
{"some-key": "some-value"}
```

Let me know what you think @duelingbanjos :)